### PR TITLE
Made writing of data output continuous

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -8,6 +8,9 @@ CAMERA_SOURCE = 0
 #you can use "camera", "ipwebcam" or "video" to select your input source
 STREAMING_SOURCE = video
 
+[Data Output]
+CSV_DELIMITER = ;
+
 [Pose Estimation]
 #possible origins are: DLC, DLC-LIVE, MADLC, DEEPPOSEKIT
 MODEL_ORIGIN = ORIGIN

--- a/utils/configloader.py
+++ b/utils/configloader.py
@@ -52,6 +52,12 @@ VIDEO_SOURCE = dsc_config['Video'].get('VIDEO_SOURCE')
 #IPWEBCAM
 PORT = dsc_config['IPWEBCAM'].get('PORT')
 
+# Data output
+
+CSV_DELIMITER = dsc_config['Data Output'].get('CSV_DELIMITER')
+if len(CSV_DELIMITER) > 1 or not isinstance(CSV_DELIMITER, str):
+    CSV_DELIMITER = ';'
+
 
 # experiment
 EXP_ORIGIN = dsc_config['Experiment'].get('EXP_ORIGIN')


### PR DESCRIPTION
Now if `--data-output-enabled` we write csv file line by line.

This is actually a very crude version, that assumes that first found row would be the most full. Also will give gibberish on any incomplete row. It just so happens that knowing full info is impossible if we are going row by row. So we need to find a way to safeguard it from incomplete data, missing joints and animals.

Also repeatedly opens and closes the actual csv file, which is not ideal for performance. Again, when we are dealing with endless loop, `with open(file)` is pretty much useless.

Maybe we need to rethink this idea somehow?